### PR TITLE
Fixed drop-downs and updated default values of state

### DIFF
--- a/client/components/ECMA_Version.jsx
+++ b/client/components/ECMA_Version.jsx
@@ -18,11 +18,15 @@ function Version(props) {
     { value: 2021, label: 2021, type: 'version' },
   ];
 
+  // defining default value of drop down menu
+  const defaultValue = { value: version, label: version };
+
   return (
     <div className="option">
       <h2 style={{ color: 'white' }}>ECMA Version</h2>
       <div className="dropDown" style={{ minWidth: '200px' }}>
         <Select
+          defaultValue={defaultValue}
           onChange={updateVersion}
           options={options}
         />

--- a/client/components/sourceType.jsx
+++ b/client/components/sourceType.jsx
@@ -11,11 +11,15 @@ function SourceType(props) {
     { value: 'script', label: 'script', type: 'sourceType' },
   ];
 
+  // defining default value of drop down menu
+  const defaultValue = { value: sourceType, label: sourceType };
+
   return (
     <div className="option">
       <h2 style={{ color: 'white' }}>Source Type</h2>
       <div className="dropDown" style={{ minWidth: '200px' }}>
         <Select
+          defaultValue={defaultValue}
           onChange={updateSourceType}
           options={options}
         />

--- a/client/components/state.js
+++ b/client/components/state.js
@@ -1,8 +1,8 @@
 // missing Enable all
 const ourState = {
   "parserOptions": {
-    "ecmaVersion": null,
-    "sourceType": null,
+    "ecmaVersion": 2016,
+    "sourceType": "module",
     "ecmaFeatures": {
         "jsx": false,
         "globalReturn": false,


### PR DESCRIPTION
Updated so that dropdowns do not revert after collapsing section. Also defaulted ECMA Version and Source Type to 2016 and "module" in state